### PR TITLE
Use the smaller, faster devkitpro-alpine-switch container image

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     
     # Use a container with Devkitpro already setup
-    container: devkitpro/devkita64:latest
+    container: pixelkiri/devkitpro-alpine-switch:latest
     steps:
     - name: Setup Checkout and Submodules
       uses: actions/checkout@v3
@@ -35,4 +35,4 @@ jobs:
         cmake-version: '3.26.x'
     
     - name: Build LunaKit
-      run: cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain.cmake -S . -B build && make -C build subsdk9_meta
+      run: cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain.cmake -S . -B build && make -C build subsdk9_meta -j4

--- a/src/program/devgui/windows/ActorBrowse/ActorBrowseChildInspect.cpp
+++ b/src/program/devgui/windows/ActorBrowse/ActorBrowseChildInspect.cpp
@@ -88,7 +88,7 @@ inline void WindowActorBrowse::drawActorInspectorTreePose(al::ActorPoseKeeperBas
     if (ImGui::TreeNode("Actor Pose")) {
         ImGuiHelper::Vector3Drag("Trans", "Pose Keeper Translation", &pose->mTranslation, 50.f, 0.f);
         ImGuiHelper::Vector3Drag("Scale", "Pose Keeper Scale", pose->getScalePtr(), 0.05f, 0.f);
-        ImGuiHelper::Vector3Drag("Velcoity", "Pose Keeper Velocity", pose->getVelocityPtr(), 1.f, 0.f);
+        ImGuiHelper::Vector3Drag("Velocity", "Pose Keeper Velocity", pose->getVelocityPtr(), 1.f, 0.f);
         ImGuiHelper::Vector3Slide("Front", "Pose Keeper Front", pose->getFrontPtr(), 1.f, true);
         ImGuiHelper::Vector3Slide("Up", "Pose Keeper Up", pose->getUpPtr(), 1.f, true);
         ImGuiHelper::Vector3Slide("Gravity", "Pose Keeper Gravity", pose->getGravityPtr(), 1.f, true);


### PR DESCRIPTION
This is a container image I've been working on, you can find the full docker commands used for building it here:
[devkitpro-alpine-switch](https://hub.docker.com/layers/pixelkiri/devkitpro-alpine-switch/latest/images/sha256-74cc3542145a2d739200bddf362dc058701862a5cbb34b1369bd5d01e0df9f1f?context=repo)

It uses alpine linux as a base image, and it's much smaller and faster that the official devkitpro image.

![image](https://github.com/Amethyst-szs/smo-lunakit/assets/6061770/0a401437-cefd-4f4c-9ab1-24b31bc4b51f)

PS: PR also fixes a small typo.
